### PR TITLE
Don't mix uint32_t and DWORD for TexLoad return type

### DIFF
--- a/src/TexLoad.h
+++ b/src/TexLoad.h
@@ -43,12 +43,12 @@
 #include <string.h>
 #endif // _WIN32
 
-DWORD LoadNone (unsigned char * dst, unsigned char * src, int wid_64, int height, int line, int real_width, int tile)
+uint32_t LoadNone (unsigned char * dst, unsigned char * src, int wid_64, int height, int line, int real_width, int tile)
 {
     return GR_TEXFMT_ARGB_1555;
 }
 
-typedef DWORD (*texfunc)(unsigned char *, unsigned char *, int, int, int, int, int);
+typedef uint32_t (*texfunc)(unsigned char *, unsigned char *, int, int, int, int, int);
 texfunc load_table [4][5] = {   // [size][format]
     { Load4bSelect, LoadNone, Load4bCI, Load4bIA,  Load4bI},
     { Load8bCI,     LoadNone, Load8bCI, Load8bIA,  Load8bI},

--- a/src/TexLoad32b.h
+++ b/src/TexLoad32b.h
@@ -38,7 +38,7 @@
 //****************************************************************
 // Size: 2, Format: 0
 
-DWORD Load32bRGBA (unsigned char * dst, unsigned char * src, int wid_64, int height, int line, int real_width, int tile)
+uint32_t Load32bRGBA (unsigned char * dst, unsigned char * src, int wid_64, int height, int line, int real_width, int tile)
 {
     uint32_t *input_pos;
     uint32_t *output_pos;

--- a/src/TexLoad4b.h
+++ b/src/TexLoad4b.h
@@ -623,7 +623,7 @@ uint32_t Load4bCI (uint8_t *dst, uint8_t *src, int wid_64, int height, int line,
 //
 // ** BY GUGAMAN **
 
-DWORD Load4bIA (unsigned char * dst, unsigned char * src, int wid_64, int height, int line, int real_width, int tile)
+uint32_t Load4bIA (unsigned char * dst, unsigned char * src, int wid_64, int height, int line, int real_width, int tile)
 {
   if (rdp.tlut_mode != 0)
     return Load4bCI (dst, src, wid_64, height, line, real_width, tile);
@@ -638,7 +638,7 @@ DWORD Load4bIA (unsigned char * dst, unsigned char * src, int wid_64, int height
 //****************************************************************
 // Size: 0, Format: 4
 
-DWORD Load4bI (unsigned char * dst, unsigned char * src, int wid_64, int height, int line, int real_width, int tile)
+uint32_t Load4bI (unsigned char * dst, unsigned char * src, int wid_64, int height, int line, int real_width, int tile)
 {
   if (rdp.tlut_mode != 0)
     return Load4bCI (dst, src, wid_64, height, line, real_width, tile);
@@ -654,7 +654,7 @@ DWORD Load4bI (unsigned char * dst, unsigned char * src, int wid_64, int height,
 //****************************************************************
 // Size: 0, Format: 0
 
-DWORD Load4bSelect (unsigned char * dst, unsigned char * src, int wid_64, int height, int line, int real_width, int tile)
+uint32_t Load4bSelect (unsigned char * dst, unsigned char * src, int wid_64, int height, int line, int real_width, int tile)
 {
   if (rdp.tlut_mode == 0)
     return Load4bI (dst, src, wid_64, height, line, real_width, tile);


### PR DESCRIPTION
MinGW fails to build it when the return type of the function pointers in the
TexLoad load_table is a mixture of uint32_t (unsigned int) and DWORD (aka long
unsigned int).
