### PR TITLE
Avoid overlapping memcpy().

### DIFF
--- a/src/TexBuffer.cpp
+++ b/src/TexBuffer.cpp
@@ -297,7 +297,7 @@ BOOL OpenTextureBuffer(COLOR_IMAGE & cimage)
                         grRenderBuffer( GR_BUFFER_BACKBUFFER );
             rdp.texbufs[i].count--;
             if (j < rdp.texbufs[i].count)
-               memcpy(&(rdp.texbufs[i].images[j]), &(rdp.texbufs[i].images[j+1]), sizeof(HIRES_COLOR_IMAGE)*(rdp.texbufs[i].count-j));
+               memmove(&(rdp.texbufs[i].images[j]), &(rdp.texbufs[i].images[j+1]), sizeof(HIRES_COLOR_IMAGE)*(rdp.texbufs[i].count-j));
           }
         }
       }
@@ -599,7 +599,7 @@ BOOL FindTextureBuffer(DWORD addr, WORD width)
         {
           rdp.texbufs[index].count--;
           if (j < rdp.texbufs[index].count)
-             memcpy(&(rdp.texbufs[index].images[j]), &(rdp.texbufs[index].images[j+1]), sizeof(HIRES_COLOR_IMAGE)*(rdp.texbufs[index].count-j));
+             memmove(&(rdp.texbufs[index].images[j]), &(rdp.texbufs[index].images[j+1]), sizeof(HIRES_COLOR_IMAGE)*(rdp.texbufs[index].count-j));
         }
       }
     }


### PR DESCRIPTION
Per the standard, memcpy()’s behavior on overlapping buffers is undefined. On OpenBSD, an overlapping memcpy triggers a crash here. Use memmove() instead, as its behavior on overlapping buffers is well defined.