### PR TITLE
Update homepage links

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -67,7 +67,7 @@ ifeq ("$(patsubst MINGW%,MINGW,$(UNAME))","MINGW")
   PIC = 0
 endif
 ifeq ("$(OS)","NONE")
-  $(error OS type "$(UNAME)" not supported.  Please file bug report at 'http://code.google.com/p/mupen64plus/issues')
+  $(error OS type "$(UNAME)" not supported.  Please file bug report at 'https://github.com/mupen64plus/mupen64plus-core/issues')
 endif
 
 # detect system architecture
@@ -114,7 +114,7 @@ ifneq ("$(filter arm%,$(HOST_CPU))","")
   endif
 endif
 ifeq ("$(CPU)","NONE")
-  $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'http://code.google.com/p/mupen64plus/issues')
+  $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'https://github.com/mupen64plus/mupen64plus-core/issues')
 endif
 
 # base CFLAGS, LDLIBS, and LDFLAGS

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -1,6 +1,6 @@
 #/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 # *   Mupen64plus-video-glide64 - Makefile                                  *
-# *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+# *   Mupen64Plus homepage: https://mupen64plus.org/                        *
 # *   Copyright (C) 2010 Jon Ring                                           *
 # *   Copyright (C) 2007-2009 Richard Goedeken                              *
 # *   Copyright (C) 2007-2008 DarkJeztr Tillin9                             *

--- a/src/osal_dynamiclib.h
+++ b/src/osal_dynamiclib.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-core - osal/dynamiclib.h                                  *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/osal_dynamiclib_unix.c
+++ b/src/osal_dynamiclib_unix.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-core - osal/dynamiclib_unix.c                             *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/osal_dynamiclib_win32.c
+++ b/src/osal_dynamiclib_win32.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-ui-console - osal_dynamiclib_win32.c                      *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/winlnxdefs.h
+++ b/src/winlnxdefs.h
@@ -2,7 +2,7 @@
  * Glide64 Video Plugin - winlnxdefs.h
  * Copyright (C) 2002 Dave2001
  *
- * Mupen64Plus homepage: http://code.google.com/p/mupen64plus/
+ * Mupen64Plus homepage: https://mupen64plus.org/             
  * 
  * This program is free software; you can redistribute it and/
  * or modify it under the terms of the GNU General Public Li-

--- a/src/wrapper/2xsai.cpp
+++ b/src/wrapper/2xsai.cpp
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - glide64/wrapper/2xsai.cpp                               *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2005-2006 Hacktarux                                     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/wrapper/2xsai.h
+++ b/src/wrapper/2xsai.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - glide64/wrapper/2xsai.h                                 *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2005-2006 Hacktarux                                     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/wrapper/combiner.cpp
+++ b/src/wrapper/combiner.cpp
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - glide64/wrapper/combiner.cpp                            *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2005-2006 Hacktarux                                     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/wrapper/config.cpp
+++ b/src/wrapper/config.cpp
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - glide64/wrapper/config.cpp                              *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2005-2006 Hacktarux                                     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/wrapper/filter.cpp
+++ b/src/wrapper/filter.cpp
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - glide64/wrapper/filter.cpp                              *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2005-2006 Hacktarux                                     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/wrapper/geometry.cpp
+++ b/src/wrapper/geometry.cpp
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - glide64/wrapper/geometry.cpp                            *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2005-2006 Hacktarux                                     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/wrapper/hq2x.cpp
+++ b/src/wrapper/hq2x.cpp
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - hq2x.cpp                                                *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2003 MaxSt ( maxst@hiend3d.com )                        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/wrapper/hq4x.cpp
+++ b/src/wrapper/hq4x.cpp
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - hq4x.cpp                                                *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2003 MaxSt ( maxst@hiend3d.com )                        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/wrapper/main.cpp
+++ b/src/wrapper/main.cpp
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - glide64/wrapper/main.cpp                                *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2005-2006 Hacktarux                                     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/wrapper/main.h
+++ b/src/wrapper/main.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - glide64/wrapper/main.h                                  *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2005-2006 Hacktarux                                     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/wrapper/textures.cpp
+++ b/src/wrapper/textures.cpp
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - glide64/wrapper/textures.cpp                            *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2005-2006 Hacktarux                                     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *


### PR DESCRIPTION
Linking to the Google Code page isn’t much use anymore.

Across all repos, I changed issue tracker links to the Github tracker, wiki links to the mupen64plus.org wiki, and homepage links to mupen64plus.org.

For the most part I didn’t link to individual repos, for maintenance reasons (if we ever move away from Github, or if we copy files across repos, or…).