### PR TITLE
Newer c++ fixes

### DIFF
--- a/src/3dmath.cpp
+++ b/src/3dmath.cpp
@@ -48,7 +48,7 @@
 void calc_light (VERTEX *v)
 {
     float light_intensity = 0.0f;
-    register float color[3] = {rdp.light[rdp.num_lights].r, rdp.light[rdp.num_lights].g, rdp.light[rdp.num_lights].b};
+    float color[3] = {rdp.light[rdp.num_lights].r, rdp.light[rdp.num_lights].g, rdp.light[rdp.num_lights].b};
     for (DWORD l=0; l<rdp.num_lights; l++)
     {
         light_intensity = DotProduct (rdp.light_vector[l], v->vec);

--- a/src/3dmath.h
+++ b/src/3dmath.h
@@ -37,16 +37,16 @@
 #include "rdp.h"
 #include "m64p.h"
 
-__inline float DotProduct(register float *v1, register float *v2)
+__inline float DotProduct(float *v1, float *v2)
 {
-    register float result;
+    float result;
     result = v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
     return(result);
 }
 
 __inline void NormalizeVector(float *v)
 {
-    register float len;
+    float len;
     len = sqrtf(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
     if (len > 0.0f)
     {

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -710,7 +710,7 @@ BOOL InitGfx (BOOL evoodoo_using_window)
       WriteLog(M64MSG_INFO, "fb_hires\n");
     GRWINOPENEXT grSstWinOpenExt = (GRWINOPENEXT)grGetProcAddress("grSstWinOpenExt");
     if (grSstWinOpenExt)
-      gfx_context = grSstWinOpenExt ((FxU32)NULL,
+      gfx_context = grSstWinOpenExt ((uintptr_t)NULL,
       settings.res_data,
       GR_REFRESH_60Hz,
       GR_COLORFORMAT_RGBA,
@@ -720,7 +720,7 @@ BOOL InitGfx (BOOL evoodoo_using_window)
       1);   // 1 auxillary buffer
   }
   if (!gfx_context)
-    gfx_context = grSstWinOpen ((FxU32)NULL,
+    gfx_context = grSstWinOpen ((uintptr_t)NULL,
     settings.res_data,
     GR_REFRESH_60Hz,
     GR_COLORFORMAT_RGBA,

--- a/src/ucode02.h
+++ b/src/ucode02.h
@@ -37,7 +37,7 @@
 static void calc_point_light (VERTEX *v, float * vpos)
 {
   float light_intensity = 0.0f;
-  register float color[3] = {rdp.light[rdp.num_lights].r, rdp.light[rdp.num_lights].g, rdp.light[rdp.num_lights].b};
+  float color[3] = {rdp.light[rdp.num_lights].r, rdp.light[rdp.num_lights].g, rdp.light[rdp.num_lights].b};
   for (DWORD l=0; l<rdp.num_lights; l++)
   {
     if (rdp.light[l].nonblack)


### PR DESCRIPTION
On OpenBSD with clang-6.0.0:

    warning: 'register' storage class specifier is deprecated and incompatible with CC++17 [-Wdeprecated-register]

    error: cast from pointer to smaller type 'FxU32' (aka 'unsigned int') loses information