### PR TITLE
Declare variables as int to avoid narrowing errors on arm64.

### DIFF
--- a/src/wrapper/filter.cpp
+++ b/src/wrapper/filter.cpp
@@ -32,8 +32,8 @@
 unsigned char *blur_edges(unsigned char *source, int width, int height, int *width2, int *height2)
 {
     unsigned char *result, *temp, *temp2;
-    char mx[3*3] = {-1, 0, 1, -2, 0, 2, -1, 0, 1};
-    char my[3*3] = {-1, -2, -1, 0, 0, 0, 1, 2 ,1};
+    int mx[3*3] = {-1, 0, 1, -2, 0, 2, -1, 0, 1};
+    int my[3*3] = {-1, -2, -1, 0, 0, 0, 1, 2 ,1};
     int i,j;
 
     *width2 = width*2;


### PR DESCRIPTION
Fixes the following error (OpenBSD/arm64/clang-7.0.1):

    c++ -fvisibility-inlines-hidden -O2 -pipe  -Wall -ffast-math -fno-strict-aliasing -fvisibility=hidden -I../../src -I../../src/wrapper -DGCC -fPIC -I/usr/X11R6/include -I/usr/X11R6/include/libdrm -I/usr/local/include -I/usr/local/include/SDL2 -I/usr/X11R6/include -D_REENTRANT -I/usr/X11R6/include "-I/usr/local/include/mupen64plus" -g -DNO_ASM -MD -MP   -c -o _obj/wrapper/filter.o ../../src/wrapper/filter.cpp
    ../../src/wrapper/filter.cpp:35:21: error: constant expression evaluates to -1 which cannot be narrowed to type 'char' [-Wc++11-narrowing]
        char mx[3*3] = {-1, 0, 1, -2, 0, 2, -1, 0, 1};
                        ^~
    ../../src/wrapper/filter.cpp:35:21: note: insert an explicit cast to silence this issue
        char mx[3*3] = {-1, 0, 1, -2, 0, 2, -1, 0, 1};
                        ^~
                        static_cast<char>( )
    ../../src/wrapper/filter.cpp:35:31: error: constant expression evaluates to -2 which cannot be narrowed to type 'char' [-Wc++11-narrowing]
        char mx[3*3] = {-1, 0, 1, -2, 0, 2, -1, 0, 1};
                                  ^~
    ../../src/wrapper/filter.cpp:35:31: note: insert an explicit cast to silence this issue
        char mx[3*3] = {-1, 0, 1, -2, 0, 2, -1, 0, 1};
                                  ^~
                                  static_cast<char>( )
    ../../src/wrapper/filter.cpp:35:41: error: constant expression evaluates to -1 which cannot be narrowed to type 'char' [-Wc++11-narrowing]
        char mx[3*3] = {-1, 0, 1, -2, 0, 2, -1, 0, 1};
                                            ^~
    ../../src/wrapper/filter.cpp:35:41: note: insert an explicit cast to silence this issue
        char mx[3*3] = {-1, 0, 1, -2, 0, 2, -1, 0, 1};
                                            ^~
                                            static_cast<char>( )
    ../../src/wrapper/filter.cpp:36:21: error: constant expression evaluates to -1 which cannot be narrowed to type 'char' [-Wc++11-narrowing]
        char my[3*3] = {-1, -2, -1, 0, 0, 0, 1, 2 ,1};
                        ^~
    ../../src/wrapper/filter.cpp:36:21: note: insert an explicit cast to silence this issue
        char my[3*3] = {-1, -2, -1, 0, 0, 0, 1, 2 ,1};
                        ^~
                        static_cast<char>( )
    ../../src/wrapper/filter.cpp:36:25: error: constant expression evaluates to -2 which cannot be narrowed to type 'char' [-Wc++11-narrowing]
        char my[3*3] = {-1, -2, -1, 0, 0, 0, 1, 2 ,1};
                            ^~
    ../../src/wrapper/filter.cpp:36:25: note: insert an explicit cast to silence this issue
        char my[3*3] = {-1, -2, -1, 0, 0, 0, 1, 2 ,1};
                            ^~
                            static_cast<char>( )
    ../../src/wrapper/filter.cpp:36:29: error: constant expression evaluates to -1 which cannot be narrowed to type 'char' [-Wc++11-narrowing]
        char my[3*3] = {-1, -2, -1, 0, 0, 0, 1, 2 ,1};
                                ^~
    ../../src/wrapper/filter.cpp:36:29: note: insert an explicit cast to silence this issue
        char my[3*3] = {-1, -2, -1, 0, 0, 0, 1, 2 ,1};
                                ^~
                                static_cast<char>( )
    6 errors generated.