### PR TITLE
build: Allow out of tree builds.

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -117,10 +117,13 @@ ifeq ("$(CPU)","NONE")
   $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'https://github.com/mupen64plus/mupen64plus-core/issues')
 endif
 
+SRCDIR = ../../src
+OBJDIR = _obj$(POSTFIX)
+
 # base CFLAGS, LDLIBS, and LDFLAGS
 OPTFLAGS ?= -O3 -flto
 WARNFLAGS ?= -Wall
-CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fno-strict-aliasing -fvisibility=hidden -I../../src -I../../src/wrapper -DGCC
+CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fno-strict-aliasing -fvisibility=hidden -I$(SRCDIR) -I$(SRCDIR)/wrapper -DGCC
 CXXFLAGS += -fvisibility-inlines-hidden
 LDFLAGS += $(SHARED)
 
@@ -298,9 +301,6 @@ ifeq ($(PLUGINDIR),)
   PLUGINDIR := $(LIBDIR)/mupen64plus
 endif
 
-SRCDIR = ../../src
-OBJDIR = _obj$(POSTFIX)
-
 # list of source files to compile
 SOURCE = \
 	$(SRCDIR)/3dmath.cpp \
@@ -374,7 +374,7 @@ install: $(TARGET)
 	$(INSTALL) -d "$(DESTDIR)$(PLUGINDIR)"
 	$(INSTALL) -m 0644 $(INSTALL_STRIP_FLAG) $(TARGET) "$(DESTDIR)$(PLUGINDIR)"
 	$(INSTALL) -d "$(DESTDIR)$(SHAREDIR)"
-	$(INSTALL) -m 0644 "../../data/Glide64.ini" "$(DESTDIR)$(SHAREDIR)"
+	$(INSTALL) -m 0644 "$(SRCDIR)/../data/Glide64.ini" "$(DESTDIR)$(SHAREDIR)"
 
 uninstall:
 	$(RM) "$(DESTDIR)$(PLUGINDIR)/$(TARGET)"


### PR DESCRIPTION
This allows building the project out of tree.

Example:
```
mkdir /tmp/build
cd /tmp/build
make install -f /path/to/mupen64plus-video-glide64/projects/unix/Makefile \
  SRCDIR=/path/to/mupen64plus-video-glide64/src
```
See PR https://github.com/mupen64plus/mupen64plus-core/pull/811 for reference.